### PR TITLE
Fix recursion base case in Display::loading

### DIFF
--- a/Software/display.cpp
+++ b/Software/display.cpp
@@ -14,8 +14,10 @@ void Display::write(unsigned short digit) {
 }
 
 void Display::loading(unsigned short repetNumber){
-	if(--repetNumber > 0)
-		loading(repetNumber);
+        if (repetNumber == 0)
+                return;
+        --repetNumber;
+        loading(repetNumber);
 
 	//TODO
 	//Serpentina iniziale


### PR DESCRIPTION
## Summary
- correct recursion logic in `Display::loading`

## Testing
- `g++ -std=c++17 -c Software/display.cpp` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b8e51db80832b8c32acf200ab54bd