### PR TITLE
Integrate NonBlockingRTTTL library for melody playback

### DIFF
--- a/Software/Melody.hpp
+++ b/Software/Melody.hpp
@@ -5,13 +5,15 @@
 #include "Notes.hpp"
 #include "Encoder.hpp"
 #include "HornButton.hpp"
+#include "lib/NonBlockingRTTTL/NonBlockingRtttl.h"
 
 #define HORN 19
 #define BUZZER 16
 
 class Melody{
-	unsigned short length, totalDuration;
-	unsigned short *notes, *notesDuration;
+        unsigned short length, totalDuration;
+        unsigned short *notes, *notesDuration;
+        String rtttl;
 	
 	String name;
 

--- a/Software/lib/NonBlockingRTTTL/NonBlockingRtttl.cpp
+++ b/Software/lib/NonBlockingRTTTL/NonBlockingRtttl.cpp
@@ -1,0 +1,371 @@
+// ---------------------------------------------------------------------------
+// Created by Antoine Beauchamp based on the code from the ToneLibrary
+//
+// See "NonBlockingRtttl.h" for purpose, syntax, version history, links, and more.
+// ---------------------------------------------------------------------------
+
+#include "Arduino.h"
+#include "NonBlockingRtttl.h"
+
+/*********************************************************
+ * RTTTL Library data
+ *********************************************************/
+
+namespace rtttl
+{
+
+const int notes[] = { 0,
+NOTE_C4, NOTE_CS4, NOTE_D4, NOTE_DS4, NOTE_E4, NOTE_F4, NOTE_FS4, NOTE_G4, NOTE_GS4, NOTE_A4, NOTE_AS4, NOTE_B4,
+NOTE_C5, NOTE_CS5, NOTE_D5, NOTE_DS5, NOTE_E5, NOTE_F5, NOTE_FS5, NOTE_G5, NOTE_GS5, NOTE_A5, NOTE_AS5, NOTE_B5,
+NOTE_C6, NOTE_CS6, NOTE_D6, NOTE_DS6, NOTE_E6, NOTE_F6, NOTE_FS6, NOTE_G6, NOTE_GS6, NOTE_A6, NOTE_AS6, NOTE_B6,
+NOTE_C7, NOTE_CS7, NOTE_D7, NOTE_DS7, NOTE_E7, NOTE_F7, NOTE_FS7, NOTE_G7, NOTE_GS7, NOTE_A7, NOTE_AS7, NOTE_B7
+};
+
+//#define isdigit(n) (n >= '0' && n <= '9')
+#define OCTAVE_OFFSET 0
+
+const char * buffer = "";
+const char * firstNote = "";
+int bufferIndex = -32760;
+byte default_dur = 4;
+byte default_oct = 5;
+int bpm = 63;
+long wholenote;
+byte pin = -1;
+unsigned long noteDelay = 0; //m will always be after which means the last note is done playing
+unsigned long loopGap;
+byte loopCount;
+bool playing = false;
+
+//pre-declaration
+void nextnote();
+
+// tone() and noTone() are not implemented for Arduino core for the ESP32
+// See https://github.com/espressif/arduino-esp32/issues/980
+// and https://github.com/espressif/arduino-esp32/issues/1720
+#if defined(ESP32)
+void noTone(){
+  ledcWrite(0, 0); // channel, volume
+}
+
+void noTone(int pin){
+  noTone();
+}
+
+void tone(int frq) {
+  ledcWriteTone(0, frq); // channel, freq
+  ledcWrite(0, 255); // channel, volume
+}
+
+void tone(int pin, int frq, int duration){
+  tone(frq);
+}
+#endif
+
+void begin(byte iPin, const char * iSongBuffer, byte iLoopCount, unsigned long iLoopGap)
+{
+  #ifdef RTTTL_NONBLOCKING_DEBUG
+  Serial.print("playing: ");
+  Serial.println(iSongBuffer);
+  #endif
+    
+  //init values
+  pin = iPin;
+  #if defined(ESP32)
+  ledcSetup(0, 1000, 10); // resolution always seems to be 10bit, no matter what is given
+  ledcAttachPin(pin, 0);
+  #endif
+  buffer = iSongBuffer;
+  bufferIndex = 0;
+  default_dur = 4;
+  default_oct = 6;
+  bpm=63;
+  playing = true;
+  noteDelay = 0;
+  loopCount = iLoopCount;
+  loopGap = iLoopGap;
+  #ifdef RTTTL_NONBLOCKING_DEBUG
+  Serial.print("noteDelay=");
+  Serial.println(noteDelay);
+  #endif
+  
+  //stop current note
+  noTone(pin);
+
+  //read buffer until first note
+  int num;
+
+  // format: d=N,o=N,b=NNN:
+  // find the start (skip name, etc)
+
+  while(*buffer != ':') buffer++;    // ignore name
+  buffer++;                     // skip ':'
+
+  // get default duration
+  if(*buffer == 'd')
+  {
+    buffer++; buffer++;              // skip "d="
+    num = 0;
+    while(isdigit(*buffer))
+    {
+      num = (num * 10) + (*buffer++ - '0');
+    }
+    if(num > 0) default_dur = num;
+    buffer++;                   // skip comma
+  }
+
+  #ifdef RTTTL_NONBLOCKING_INFO
+  Serial.print("ddur: "); Serial.println(default_dur, 10);
+  #endif
+  
+  // get default octave
+  if(*buffer == 'o')
+  {
+    buffer++; buffer++;              // skip "o="
+    num = *buffer++ - '0';
+    if(num >= 3 && num <=7) default_oct = num;
+    buffer++;                   // skip comma
+  }
+
+  #ifdef RTTTL_NONBLOCKING_INFO
+  Serial.print("doct: "); Serial.println(default_oct, 10);
+  #endif
+  
+  // get BPM
+  if(*buffer == 'b')
+  {
+    buffer++; buffer++;              // skip "b="
+    num = 0;
+    while(isdigit(*buffer))
+    {
+      num = (num * 10) + (*buffer++ - '0');
+    }
+    bpm = num;
+    buffer++;                   // skip colon
+  }
+
+  #ifdef RTTTL_NONBLOCKING_INFO
+  Serial.print("bpm: "); Serial.println(bpm, 10);
+  #endif
+
+  // BPM usually expresses the number of quarter notes per minute
+  wholenote = (60 * 1000L / bpm) * 4;  // this is the time for whole note (in milliseconds)
+
+  firstNote = buffer;
+
+  #ifdef RTTTL_NONBLOCKING_INFO
+  Serial.print("wn: "); Serial.println(wholenote, 10);
+  #endif
+}
+
+void nextnote()
+{
+  long duration;
+  byte note;
+  byte scale;
+
+  //stop current note
+  noTone(pin);
+
+  // first, get note duration, if available
+  int num = 0;
+  while(isdigit(*buffer))
+  {
+    num = (num * 10) + (*buffer++ - '0');
+  }
+  
+  if(num) duration = wholenote / num;
+  else duration = wholenote / default_dur;  // we will need to check if we are a dotted note after
+
+  // now get the note
+  note = 0;
+
+  switch(*buffer)
+  {
+    case 'c':
+      note = 1;
+      break;
+    case 'd':
+      note = 3;
+      break;
+    case 'e':
+      note = 5;
+      break;
+    case 'f':
+      note = 6;
+      break;
+    case 'g':
+      note = 8;
+      break;
+    case 'a':
+      note = 10;
+      break;
+    case 'b':
+      note = 12;
+      break;
+    case 'p':
+    default:
+      note = 0;
+  }
+  buffer++;
+
+  // now, get optional '#' sharp
+  if(*buffer == '#')
+  {
+    note++;
+    buffer++;
+  }
+
+  // now, get optional '.' dotted note
+  if(*buffer == '.')
+  {
+    duration += duration/2;
+    buffer++;
+  }
+
+  // now, get scale
+  if(isdigit(*buffer))
+  {
+    scale = *buffer - '0';
+    buffer++;
+  }
+  else
+  {
+    scale = default_oct;
+  }
+
+  scale += OCTAVE_OFFSET;
+
+  // now, get optional '.' dotted note again.
+  // A dot /after/ the octave is allowed too, depending on which
+  // RTTTL specification you read.
+  // See https://github.com/end2endzone/NonBlockingRTTTL/issues/10
+  if(*buffer == '.')
+  {
+    duration += duration/2;
+    buffer++;
+  }
+
+  if(*buffer == ',')
+    buffer++;       // skip comma for next note (or we may be at the end)
+
+  // now play the note
+
+  if(note)
+  {
+    #ifdef RTTTL_NONBLOCKING_INFO
+    Serial.print("Playing: ");
+    Serial.print(scale, 10); Serial.print(' ');
+    Serial.print(note, 10); Serial.print(" (");
+    Serial.print(notes[(scale - 4) * 12 + note], 10);
+    Serial.print(") ");
+    Serial.println(duration, 10);
+    #endif
+    
+    tone(pin, notes[(scale - 4) * 12 + note], duration);
+    
+    noteDelay = millis() + (duration+1);
+  }
+  else
+  {
+    #ifdef RTTTL_NONBLOCKING_INFO
+    Serial.print("Pausing: ");
+    Serial.println(duration, 10);
+    #endif
+    
+    noteDelay = millis() + (duration);
+  }
+}
+
+void play()
+{
+  //if done playing the song, return
+  if (!playing)
+  {
+    #ifdef RTTTL_NONBLOCKING_DEBUG
+    Serial.println("done playing...");
+    #endif
+    
+    return;
+  }
+  
+  //are we still playing a note ?
+  unsigned long m = millis();
+  if (m < noteDelay)
+  {
+    #ifdef RTTTL_NONBLOCKING_DEBUG
+    Serial.println("still playing a note...");
+    #endif
+    
+    //wait until the note is completed
+    return;
+  }
+
+  //ready to play the next note
+  if (*buffer == '\0')
+  {
+    //no more notes. Reached the end of the last note
+
+    #ifdef RTTTL_NONBLOCKING_DEBUG
+    Serial.println("end of note...");
+    #endif
+    
+    //issue #6: Bug for ESP8266 environment - noTone() not called at end of sound.
+    //disable sound at the end of a normal playback.
+    if(--loopCount) {
+      noteDelay = millis() + loopGap;
+      buffer = firstNote;
+
+      #ifdef RTTTL_NONBLOCKING_INFO
+        Serial.print("Loop n°");
+        Serial.print(loopCount, 10);
+        Serial.print(" with delay gap ");
+        Serial.print(loopGap, 10);
+        Serial.println("ms");
+      #endif
+    }
+    else stop();
+
+    return; //end of the song
+  }
+  else
+  {
+    //more notes to play...
+
+    #ifdef RTTTL_NONBLOCKING_DEBUG
+    Serial.println("next note...");
+    #endif
+    
+    nextnote();
+  }
+}
+
+void stop()
+{
+  if (playing)
+  {
+    //increase song buffer until the end
+    while (*buffer != '\0')
+    {
+      buffer++;
+    }
+
+    //issue #6: Bug for ESP8266 environment - noTone() not called at end of sound.
+    //disable sound if one abort playback using the stop() command.
+    noTone(pin);
+
+    playing = false;
+  }
+}
+
+bool done()
+{
+  return !playing;
+}
+
+bool isPlaying()
+{
+  return playing;
+}
+
+}; //namespace

--- a/Software/lib/NonBlockingRTTTL/NonBlockingRtttl.h
+++ b/Software/lib/NonBlockingRTTTL/NonBlockingRtttl.h
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------------
+// AUTHOR/LICENSE:
+//  The following code was written by Antoine Beauchamp. For other authors, see AUTHORS file.
+//  The code & updates for the library can be found at http://github.com/end2endzone/NonBlockingRTTTL
+//  Original source code for the RTTL player: https://code.google.com/archive/p/rogue-code/wikis/ToneLibraryDocumentation.wiki
+//  MIT License: http://www.opensource.org/licenses/mit-license.php
+// ---------------------------------------------------------------------------
+
+#ifndef NonBlockingRtttl_h
+#define NonBlockingRtttl_h
+
+#define NONBLOCKINGRTTTL_VERSION 1.3.0
+
+#include "Arduino.h"
+
+//if notes are not already defined
+#ifndef NOTE_B0
+
+#define NOTE_H   0
+#define NOTE_B0  31
+#define NOTE_C1  33
+#define NOTE_CS1 35
+#define NOTE_D1  37
+#define NOTE_DS1 39
+#define NOTE_E1  41
+#define NOTE_F1  44
+#define NOTE_FS1 46
+#define NOTE_G1  49
+#define NOTE_GS1 52
+#define NOTE_A1  55
+#define NOTE_AS1 58
+#define NOTE_B1  62
+#define NOTE_C2  65
+#define NOTE_CS2 69
+#define NOTE_D2  73
+#define NOTE_DS2 78
+#define NOTE_E2  82
+#define NOTE_F2  87
+#define NOTE_FS2 93
+#define NOTE_G2  98
+#define NOTE_GS2 104
+#define NOTE_A2  110
+#define NOTE_AS2 117
+#define NOTE_B2  123
+#define NOTE_C3  131
+#define NOTE_CS3 139
+#define NOTE_D3  147
+#define NOTE_DS3 156
+#define NOTE_E3  165
+#define NOTE_F3  175
+#define NOTE_FS3 185
+#define NOTE_G3  196
+#define NOTE_GS3 208
+#define NOTE_A3  220
+#define NOTE_AS3 233
+#define NOTE_B3  247
+#define NOTE_C4  262
+#define NOTE_CS4 277
+#define NOTE_D4  294
+#define NOTE_DS4 311
+#define NOTE_E4  330
+#define NOTE_F4  349
+#define NOTE_FS4 370
+#define NOTE_G4  392
+#define NOTE_GS4 415
+#define NOTE_A4  440
+#define NOTE_AS4 466
+#define NOTE_B4  494
+#define NOTE_C5  523
+#define NOTE_CS5 554
+#define NOTE_D5  587
+#define NOTE_DS5 622
+#define NOTE_E5  659
+#define NOTE_F5  698
+#define NOTE_FS5 740
+#define NOTE_G5  784
+#define NOTE_GS5 831
+#define NOTE_A5  880
+#define NOTE_AS5 932
+#define NOTE_B5  988
+#define NOTE_C6  1047
+#define NOTE_CS6 1109
+#define NOTE_D6  1175
+#define NOTE_DS6 1245
+#define NOTE_E6  1319
+#define NOTE_F6  1397
+#define NOTE_FS6 1480
+#define NOTE_G6  1568
+#define NOTE_GS6 1661
+#define NOTE_A6  1760
+#define NOTE_AS6 1865
+#define NOTE_B6  1976
+#define NOTE_C7  2093
+#define NOTE_CS7 2217
+#define NOTE_D7  2349
+#define NOTE_DS7 2489
+#define NOTE_E7  2637
+#define NOTE_F7  2794
+#define NOTE_FS7 2960
+#define NOTE_G7  3136
+#define NOTE_GS7 3322
+#define NOTE_A7  3520
+#define NOTE_AS7 3729
+#define NOTE_B7  3951
+#define NOTE_C8  4186
+#define NOTE_CS8 4435
+#define NOTE_D8  4699
+#define NOTE_DS8 4978
+
+//if notes are not already defined
+#endif
+
+//#define RTTTL_NONBLOCKING_DEBUG
+//#define RTTTL_NONBLOCKING_INFO
+
+namespace rtttl
+{
+
+/****************************************************************************
+ * Description:
+ *   begin() setups the NON-BLOCKING RTTTL library for
+ *   decoding a new RTTTL song.
+ * Parameters:
+ *   iPin:        The pin which is connected to the piezo buffer.
+ *   iSongBuffer: The string buffer of the RTTTL song.
+ *   iLoopCount:  Number of times the RTTTL song will be playback (default = 1).
+ *   iLoopGap:    Pause of milliseconds between the song repetition (default = 1000ms).
+ ****************************************************************************/
+void begin(byte iPin, const char * iSongBuffer, byte iLoopCount = 1, unsigned long iLoopGap = 1000);
+
+/****************************************************************************
+ * Description:
+ *   play() automatically plays a new note when required.
+ *   This function must constantly be called within the loop() function.
+ *   Warning: inserting too long delays within the loop function may
+ *   disrupt the NON-BLOCKING RTTTL library from playing properly.
+ ****************************************************************************/
+void play();
+
+/****************************************************************************
+ * Description:
+ *   stop() stops playing the current song.
+ ****************************************************************************/
+void stop();
+
+/****************************************************************************
+ * Description:
+ *   isPlaying() return true when the library is playing
+ *   the given RTTTL song.
+ ****************************************************************************/
+bool isPlaying();
+
+/****************************************************************************
+ * Description:
+ *   done() return true when the library is done playing
+ *   the given RTTTL song.
+ ****************************************************************************/
+bool done();
+
+}; //namespace
+
+//NonBlockingRtttl_h
+#endif

--- a/Software/melody.cpp
+++ b/Software/melody.cpp
@@ -1,48 +1,65 @@
 #include "Melody.hpp"
 
+static const struct NoteMap{unsigned short value; const char *name;} noteMap[] = {
+        {NOTE_A4, "a4"}, {NOTE_A5, "a5"}, {NOTE_A6, "a6"}, {NOTE_A7, "a7"},
+        {NOTE_AS4, "a#4"}, {NOTE_AS5, "a#5"}, {NOTE_B4, "b4"}, {NOTE_B5, "b5"},
+        {NOTE_C4, "c4"}, {NOTE_C5, "c5"}, {NOTE_C6, "c6"},
+        {NOTE_CS4, "c#4"}, {NOTE_CS5, "c#5"}, {NOTE_D4, "d4"},
+        {NOTE_D5, "d5"}, {NOTE_D6, "d6"}, {NOTE_D7, "d7"},
+        {NOTE_DS4, "d#4"}, {NOTE_DS5, "d#5"}, {NOTE_E4, "e4"},
+        {NOTE_E5, "e5"}, {NOTE_E6, "e6"}, {NOTE_E7, "e7"},
+        {NOTE_F4, "f4"}, {NOTE_F5, "f5"}, {NOTE_F6, "f6"},
+        {NOTE_FS5, "f#5"}, {NOTE_FS6, "f#6"}, {NOTE_FS7, "f#7"},
+        {NOTE_G4, "g4"}, {NOTE_G5, "g5"}, {NOTE_GS4, "g#4"},
+        {NOTE_GS5, "g#5"}, {NOTE_GS7, "g#7"}, {0, "p"}
+};
+
+static const char* noteName(unsigned short note){
+        for(unsigned int i=0;i<sizeof(noteMap)/sizeof(noteMap[0]);++i){
+                if(noteMap[i].value==note) return noteMap[i].name;
+        }
+        return "p";
+}
+
+static String toRtttl(const String &name, unsigned short totalDuration, unsigned short length, unsigned short *notes, unsigned short *durations){
+        String res = name + ":d=4,o=5,b=" + String(240000/totalDuration) + ":";
+        for(unsigned short i=0;i<length;i++){
+                res += String(durations[i]) + noteName(notes[i]);
+                if(i < length-1) res += ",";
+        }
+        return res;
+}
+
 Melody::Melody(String name, unsigned short totalDuration, unsigned short length, unsigned short* notes, unsigned short* notesDuration){
-	this->name = name;
-	this->totalDuration = totalDuration;
-	this->length = length;
-	this->notes = notes;
-	this->notesDuration = notesDuration;
+        this->name = name;
+        this->totalDuration = totalDuration;
+        this->length = length;
+        this->notes = notes;
+        this->notesDuration = notesDuration;
+        this->rtttl = toRtttl(name, totalDuration, length, notes, notesDuration);
 }
 	
 void Melody::play(unsigned short pauseBetweenNotes){
-	unsigned short i = 0, duration;
-
-	do{
-		duration = totalDuration / notesDuration[i];
-		tone(HORN, notes[i], duration);
-		delay(pauseBetweenNotes * duration);
-		noTone(HORN);
-		
-	}while(i++ < length);
+        rtttl::begin(HORN, rtttl.c_str());
+        while(!rtttl::done()){
+                rtttl::play();
+        }
 }
 
 short Melody::preview(unsigned short pauseBetweenNotes){
-	unsigned short i = 0, duration;
-
-	//Stop if hornButton is pressed!!!
-	while(!hornButton()){
-		duration = totalDuration / notesDuration[i];
-		tone(BUZZER, notes[i], duration);
-		delay(pauseBetweenNotes * duration);
-		noTone(BUZZER);
-
-		if(++i == length)
-			break;
-
-		if(encoder.clickListener())// Stop if encoder confirm the melody
-			return 0;
-
-		if(encoder.valueListener()){// Stop if encoder value change
-			Serial.println("Cambio canzione");
-			return 1;
-		}
-	}
-	Serial.println("Fine canzone");
-	return 2;
+        rtttl::begin(BUZZER, rtttl.c_str());
+        while(!hornButton()){
+                if(rtttl::done())
+                        return 2;
+                if(encoder.clickListener())
+                        return 0;
+                if(encoder.valueListener()){
+                        Serial.println("Cambio canzione");
+                        return 1;
+                }
+                rtttl::play();
+        }
+        return 2;
 }
 
 String Melody::getName(void){


### PR DESCRIPTION
## Summary
- add NonBlockingRTTTL library (MIT licensed) under `Software/lib`
- convert melodies to RTTTL strings on construction
- use `rtttl` library for playing and previewing melodies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b98bbae38832b9817dc93607c9262